### PR TITLE
fix: property `style` of `<Balancer />` component is not inherited

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -147,6 +147,7 @@ export default defineComponent({
         'data-brr': props.ratio,
         'ref': wrapperRef,
         'style': {
+          ...attrs?.style,
           display: 'inline-block',
           verticalAlign: 'top',
           textDecoration: 'inherit',


### PR DESCRIPTION
Hey there, thank you for the port! I saw this module for react and I am happy to use it in my nuxt app.

This PR fixes that you cannot use the `style` property of the `<Balancer />` component, because it does not get inherited/merged with the styles the wrap-balancer defines.

```vue
<template>
	<Balancer :style="{ margin: '10px' }">
		Content Lorem Ipsum
	</Balancer>
</template>
```

