### PR TITLE
Fix component rendering

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -140,7 +140,7 @@ export default defineComponent({
       }
     })
 
-    return () => withDirectives(h(tag, {
+    return () => withDirectives(h(As, {
       ...attrs,
       'data-brr': props.ratio,
       'ref': wrapperRef,

--- a/src/index.ts
+++ b/src/index.ts
@@ -140,23 +140,23 @@ export default defineComponent({
       }
     })
 
-    return () => [
-      withDirectives(h(As, {
-        ...attrs,
-        'data-brr': props.ratio,
-        'ref': wrapperRef,
-        'style': {
-          ...attrs.style as Record<string, string>,
-          display: 'inline-block',
-          verticalAlign: 'top',
-          textDecoration: 'inherit',
-        },
-      }, slots.default?.()), [
-        [vBindOnce, ['data-br', id]],
-      ]),
+    return () => withDirectives(h(tag, {
+      ...attrs,
+      'data-brr': props.ratio,
+      'ref': wrapperRef,
+      'style': {
+        ...attrs.style as Record<string, string>,
+        display: 'inline-block',
+        verticalAlign: 'top',
+        textDecoration: 'inherit',
+      },
+    }, [
+      slots.default?.(),
       withDirectives(createScriptElement(hasProvider, `self.${SYMBOL_KEY}(document.currentScript.dataset.ssrId,${props.ratio})`), [
-        [vBindOnce, ['data-ssr-id', id]],
-      ]),
-    ]
+        [vBindOnce, ['data-ssr-id', id]]],
+      ),
+    ]), [
+      [vBindOnce, ['data-br', id]],
+    ])
   },
 })


### PR DESCRIPTION
While using it, i noticed that the component loses `data-v` so it cannot be used in conjunction with scoped styles. I noticed that the problem is returned array (`() => [...]`). Instead, I return `() => withDirectives(...)` directly, and moved `script` inside the component.

In my opinion, this has an additional advantage, because it does not generate elements outside the component in the DOM, which can also have negative and unexpected effects.